### PR TITLE
Add model type override

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ Metrics/BlockLength:
   Max: 30
   ExcludedMethods:
     - describe
+    - shared_examples
 
 Metrics/LineLength:
   Max: 100

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.1.8
+  - add `model` override on GraphQL::ObjectTypes for when names don't line up
+
 0.1.6
   - last gem version didn't build correctly
 

--- a/graphql_includable.gemspec
+++ b/graphql_includable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'graphql_includable'
-  s.version = '0.1.7'
+  s.version = '0.1.8'
   s.licenses = ['MIT']
   s.summary = 'An ActiveSupport::Concern for GraphQL Ruby to eager-load query data'
   s.authors = ['Dan Rouse', 'Josh Vickery']

--- a/graphql_includable.gemspec
+++ b/graphql_includable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'graphql_includable'
-  s.version = '0.1.6'
+  s.version = '0.1.7'
   s.licenses = ['MIT']
   s.summary = 'An ActiveSupport::Concern for GraphQL Ruby to eager-load query data'
   s.authors = ['Dan Rouse', 'Josh Vickery']

--- a/lib/graphql_includable.rb
+++ b/lib/graphql_includable.rb
@@ -124,13 +124,14 @@ module GraphQLIncludable
   # get a 1d array of the chain of delegated model names,
   # so if model A delegates method B to model C, which delegates method B to model D,
   # delegated_includes_chain(A, :B) => [:C, :D]
-  def self.delegated_includes_chain(model, method_name)
+  def self.delegated_includes_chain(base_model, method_name)
     chain = []
-    delegated_model_name = model.delegate_cache.try(:[], method_name.to_sym)
-    while delegated_model_name
-      chain << delegated_model_name
-      delegated_model = model_name_to_class(delegated_model_name)
-      delegated_model_name = delegated_model.delegate_cache.try(:[], method_name.to_sym)
+    method = method_name.to_sym
+    model_name = base_model.instance_variable_get('@delegate_cache').try(:[], method)
+    while model_name
+      chain << model_name
+      model = model_name_to_class(model_name)
+      model_name = model.instance_variable_get('@delegate_cache').try(:[], method)
     end
     chain
   end

--- a/lib/graphql_includable.rb
+++ b/lib/graphql_includable.rb
@@ -5,6 +5,10 @@ GraphQL::Field.accepts_definitions(
   includes: GraphQL::Define.assign_metadata_key(:includes)
 )
 
+GraphQL::ObjectType.accepts_definitions(
+  model: GraphQL::Define.assign_metadata_key(:model)
+)
+
 module GraphQLIncludable
   extend ActiveSupport::Concern
 
@@ -86,12 +90,13 @@ module GraphQLIncludable
   end
 
   def self.node_return_class(node)
-    # rubocop:disable Lint/HandleExceptions, Style/RedundantBegin
+    return_type = node_return_type(node)
+    # rubocop:disable Lint/HandleExceptions
     begin
-      Object.const_get(node_return_type(node).name)
+      return_type.metadata[:model] || Object.const_get(return_type.name)
     rescue NameError
     end
-    # rubocop:enable Lint/HandleExceptions, Style/RedundantBegin
+    # rubocop:enable Lint/HandleExceptions
   end
 
   def self.node_returns_active_record?(node)

--- a/spec/lib/graphql_includable_spec.rb
+++ b/spec/lib/graphql_includable_spec.rb
@@ -57,4 +57,11 @@ RSpec.describe GraphQLIncludable, type: :concern do
       expect(includes).to eq([{ apples: [:tree] }])
     end
   end
+
+  context 'when explicitly defining model names' do
+    it 'resolves using the defined model name' do
+      schema.execute('{ prefixedTree { apples { __typename } } }')
+      expect(includes).to eq([:apples])
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ end
 class Tree < ActiveRecord::Base
   include GraphQLIncludable
   has_many :apples
+  has_many :prefixedApples
   has_one :tree_roots
   delegate :worms, to: :apples
 
@@ -40,6 +41,18 @@ AppleType = GraphQL::ObjectType.define do
   field :tree, !TreeType
   field :seeds, !types[types.String]
   field :juice, !types.Int
+end
+
+PrefixedAppleType = GraphQL::ObjectType.define do
+  name 'PrefixedApple'
+  model Apple
+  field :tree, !TreeType
+end
+
+PrefixedTreeType = GraphQL::ObjectType.define do
+  name 'PrefixedTree'
+  model Tree
+  field :apples, !types[!PrefixedAppleType]
 end
 
 TreeType = GraphQL::ObjectType.define do
@@ -86,6 +99,12 @@ shared_examples 'graphql' do
       field :tree, TreeType do
         resolve ->(_obj, _args, ctx) do
           private_includes = GraphQLIncludable.generate_includes_from_graphql(ctx, 'Tree')
+          nil
+        end
+      end
+      field :prefixedTree, PrefixedTreeType do
+        resolve ->(_obj, _args, ctx) do
+          private_includes = GraphQLIncludable.generate_includes_from_graphql(ctx, 'PrefixedTree')
           nil
         end
       end


### PR DESCRIPTION
This PR allows for GraphQL ObjectTypes to override their corresponding ActiveModel type. This helps us in production as our ActiveRecord `Event` model is represented by the GraphQL `SquareFootEventType`.