### PR TITLE
graphql_includable 0.2.10

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,6 @@ Metrics/LineLength:
 
 Metrics/ModuleLength:
   Max: 150
+
+Metrics/ClassLength:
+  Max: 200

--- a/graphql_includable.gemspec
+++ b/graphql_includable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'graphql_includable'
-  s.version = '0.2.9'
+  s.version = '0.2.10'
   s.licenses = ['MIT']
   s.summary = 'An ActiveSupport::Concern for GraphQL Ruby to eager-load query data'
   s.authors = ['Dan Rouse', 'Josh Vickery']

--- a/lib/graphql_includable/concern.rb
+++ b/lib/graphql_includable/concern.rb
@@ -5,7 +5,7 @@ module GraphQLIncludable
   # ActiveSupport::Concern to include onto GraphQL-mapped models
   module Concern
     extend ActiveSupport::Concern
-    # logger = Logger.new(STDOUT)
+    logger = Logger.new(STDOUT)
 
     module ClassMethods
       # Main entry point of the concern, to be called from top-level fields
@@ -18,7 +18,7 @@ module GraphQLIncludable
         # As this feature is just for a performance gain, it should never
         # fail destructively, so catch and log all exceptions, but continue
         raise e if Rails && Rails.env.development?
-        logger.info(e, e.backtrace.join('\n'))
+        logger.info("#{e.message}\n#{e.backtrace.join('\n')}")
         self
       end
 

--- a/lib/graphql_includable/concern.rb
+++ b/lib/graphql_includable/concern.rb
@@ -9,6 +9,7 @@ module GraphQLIncludable
     module ClassMethods
       # Main entry point of the concern, to be called from top-level fields
       # Accepts a graphql-ruby query context, preloads, and returns itself
+      # @param ctx GraphQL::Query::Context
       def includes_from_graphql(ctx)
         node = GraphQLIncludable::Resolver.find_node_by_return_type(ctx.irep_node, name)
         generated_includes = GraphQLIncludable::Resolver.includes_for_node(node)

--- a/lib/graphql_includable/concern.rb
+++ b/lib/graphql_includable/concern.rb
@@ -5,7 +5,6 @@ module GraphQLIncludable
   # ActiveSupport::Concern to include onto GraphQL-mapped models
   module Concern
     extend ActiveSupport::Concern
-    logger = Logger.new(STDOUT)
 
     module ClassMethods
       # Main entry point of the concern, to be called from top-level fields
@@ -18,7 +17,7 @@ module GraphQLIncludable
         # As this feature is just for a performance gain, it should never
         # fail destructively, so catch and log all exceptions, but continue
         raise e if Rails && Rails.env.development?
-        logger.info("#{e.message}\n#{e.backtrace.join('\n')}")
+        Rails.logger.debug("#{e.message}\n#{e.backtrace.join('\n')}")
         self
       end
 

--- a/lib/graphql_includable/edge.rb
+++ b/lib/graphql_includable/edge.rb
@@ -1,34 +1,41 @@
 module GraphQLIncludable
   class Edge < GraphQL::Relay::Edge
-    # Retrieve the record representing the edge between node and parent
+    # edge_record represents the data in between `node` and `parent`,
+    # basically the `through` record in a has-many-through association
     def edge_record
-      return @edge_record if @edge_record.present?
+      @edge_record ||= edge_record_from_memory || edge_record_from_database
+    end
 
-      record_set = associations_between_node_and_parent.reverse.reduce(parent) { |acc, cur| acc.send(cur) }
-      if record_set.loaded?
-        @edge_record ||= record_set.first do |rec|
-          rec.send(root_association_key) == parent &&
-          rec.send(node.class.name.downcase.to_sym) == node
-        end
-      else
-        first_association, *nested_associations = associations_between_node_and_parent
-        edge_class = self.class.str_to_class(first_association)
-        root_association_key = root_association_key(edge_class)
+    # attempt to query the edge record freshly from the database
+    def edge_record_from_database
+      first_association, *nested_associations = associations_between_node_and_parent
+      edge_class = self.class.str_to_class(first_association)
+      root_association_key = root_association_key(edge_class)
 
-        selector = edge_class
+      selector = edge_class
 
-        if nested_associations.present?
-          nested_association_names = nested_associations.map { |s| s.to_s.singularize }
-          selector = selector.merge(edge_class.includes(*nested_association_names))
-        end
+      if nested_associations.present?
+        nested_association_names = nested_associations.map { |s| s.to_s.singularize }
+        selector = selector.merge(edge_class.includes(*nested_association_names))
+      end
 
-        if class_is_polymorphic?(edge_class)
-          selector = selector.merge(edge_class.joins(root_association_key))
-        end
+      if class_is_polymorphic?(edge_class)
+        selector = selector.merge(edge_class.joins(root_association_key))
+      end
 
-        @edge_record = selector.find_by(
-          where_hash_for_edge(root_association_key, nested_associations)
-        )
+      @edge_record = selector.find_by(
+        where_hash_for_edge(root_association_key, nested_associations)
+      )
+    end
+
+    # attempt to pull the preloaded edge record out of the associated object in memory
+    def edge_record_from_memory
+      associations = associations_between_node_and_parent
+      records = associations.reverse.reduce(parent) { |acc, cur| acc.send(cur) }
+      return unless records.loaded?
+      records.first do |rec|
+        child_association_name = node.class.name.downcase.to_sym
+        rec.send(root_association_key) == parent && rec.send(child_association_name) == node
       end
     end
 

--- a/lib/graphql_includable/edge.rb
+++ b/lib/graphql_includable/edge.rb
@@ -74,8 +74,6 @@ module GraphQLIncludable
     end
 
     class << self
-      private
-
       def str_to_class(str)
         str.to_s.singularize.camelize.constantize
       rescue # rubocop:disable Lint/HandleExceptions

--- a/lib/graphql_includable/resolver.rb
+++ b/lib/graphql_includable/resolver.rb
@@ -1,7 +1,11 @@
+# Includes = Symbol | Array<Symbol> | Hash<Symbol, Includes>
 module GraphQLIncludable
   class Resolver
     class << self
       # Returns the first node in the tree which returns a specific type
+      # @param node GraphQL::InternalRepresentation::Node
+      # @param desired_return_type String
+      # @returns matching_node GraphQL::InternalRepresentation::Node
       def find_node_by_return_type(node, desired_return_type)
         return_type = node.return_type.unwrap.to_s
         return node if return_type == desired_return_type
@@ -16,51 +20,81 @@ module GraphQLIncludable
         matching_node
       end
 
-      # Translate a node's selections into `includes` values
+      # Collect preloadable relationships for the resolution of `node`
+      #
+      # @param node GraphQL::InternalRepresentation::Node
+      # @returns includes Includes
       def includes_for_node(node)
         return_model = node_return_model(node)
         return [] if return_model.blank?
         children = node.scoped_children[node.return_type.unwrap]
-        child_includes = children.map { |_key, child| includes_for_child(child, return_model) }
+        child_includes = children.map { |_key, child| includes_for_node_child(child, return_model) }
         combine_child_includes(child_includes)
       end
 
-      # Check each child of a node for a preloadable association
-      def includes_for_child(node, parent_model)
+      # Collect preloadable relationships for all selections on `node`,
+      # as accessed from `parent_model`.
+      #
+      # @param node GraphQL::InternalRepresentation::Node
+      # @param parent_model ActiveRecord::Base
+      # @returns child_includes Includes
+      def includes_for_node_child(node, parent_model)
         included_attributes = node_includes_source_from_metadata(node)
         return included_attributes if included_attributes.is_a?(Hash)
         included_attributes = [included_attributes] unless included_attributes.is_a?(Array)
         includes = included_attributes.map do |attribute_name|
-          includes_for_child_for_attribute(node, parent_model, attribute_name)
+          includes_for_node_child_attribute(node, parent_model, attribute_name)
         end
         includes.size == 1 ? includes.first : includes
       end
 
-      def includes_for_child_for_attribute(node, parent_model, attribute_name)
+      # Collect preloadable relationships for a single selection on `node`,
+      # as accessed from `parent_model`
+      #
+      # @param node GraphQL::InternalRepresentation::Node
+      # @param parent_model ActiveRecord::Base
+      # @param attribute_name Symbol
+      # @returns includes Includes
+      def includes_for_node_child_attribute(node, parent_model, attribute_name)
         includes_array = includes_delegated_through(parent_model, attribute_name)
         target_model = model_name_to_class(includes_array.last) || parent_model
         association = target_model.reflect_on_association(attribute_name)
 
         if association && node_is_relay_connection?(node)
-          includes_array << includes_for_relay_child(node, attribute_name, association)
+          includes_array << includes_for_node_relay_child_attribute(
+            node, attribute_name, association
+          )
         elsif association
           includes_array += [attribute_name, includes_for_node(node)]
         end
         array_to_nested_hash(includes_array)
       end
 
-      # Resolve includes through 'edges' and 'nodes' fields of Relay Connection types
-      def includes_for_relay_child(node, attribute_name, association)
+      # Collect preloadable relationships for a single selection on `node`,
+      # as accessed from `parent_model`, through the Relay specification's
+      # named `edges` and `nodes` selections.
+      #
+      # @param node GraphQL::InternalRepresentation::Node
+      # @param attribute_name Symbol
+      # @param association ActiveRecord::HasManyThroughAssociation
+      def includes_for_node_relay_child_attribute(node, attribute_name, association)
         children = node.scoped_children[node.return_type.unwrap]
 
-        edge_data = flat_includes_for_relay_edges(children['edges'], attribute_name, association)
+        edge_data = includes_for_node_relay_child_edge_attribute(
+          children['edges'], attribute_name, association
+        )
         leaf_data = [attribute_name, includes_for_node(node)] if children['nodes']
 
         [array_to_nested_hash(edge_data), array_to_nested_hash(leaf_data)].reject(&:blank?)
       end
 
-      # Resolve associations through a relay Edge, which may itself contain nodes
-      def flat_includes_for_relay_edges(node, attribute_name, association)
+      # Collect preloadable relationships for a single selection on `node`,
+      # a Relay Edge node whose parent is a Connection being accessed from `parent_model`
+      #
+      # @param node GraphQL::InternalRepresentation::Node
+      # @param attribute_name Symbol
+      # @param association ActiveRecord::HasManyThroughAssociation
+      def includes_for_node_relay_child_edge_attribute(node, attribute_name, association)
         return unless node
         leaf_includes = [attribute_name.to_s.singularize.to_sym]
         edge_children = node.scoped_children[node.return_type.unwrap]
@@ -77,6 +111,9 @@ module GraphQLIncludable
       # multiple terminal nodes become arrays of symbols,
       # and branching nodes become hashes.
       # The result can be passed directly into ActiveModel::Base.includes
+      #
+      # @param child_includes Includes
+      # @returns child_includes Includes
       def combine_child_includes(child_includes)
         includes = []
         nested_includes = {}
@@ -95,6 +132,9 @@ module GraphQLIncludable
 
       # Retrieve the Ruby class for a model by name
       # Attempts to singularize the name if not found
+      #
+      # @param model_name Symbol | String
+      # @returns klass Class
       def model_name_to_class(model_name)
         begin
           model_name.to_s.camelize.constantize
@@ -105,6 +145,9 @@ module GraphQLIncludable
       end
 
       # Translate a node's return type to an ActiveRecord model
+      #
+      # @param node GraphQL::InternalRepresentation::Node
+      # @returns model ActiveRecord::Base | nil
       REGEX_CLEAN_GQL_TYPE_NAME = /(^SquareFoot|Edge$|Connection$)/
       def node_return_model(node)
         model = Object.const_get(node.return_type.unwrap.name.gsub(REGEX_CLEAN_GQL_TYPE_NAME, ''))
@@ -112,12 +155,17 @@ module GraphQLIncludable
       rescue NameError # rubocop:disable Lint/HandleExceptions
       end
 
+      # @param node GraphQL::InternalRepresentation::Node
+      # @returns is_relay_connection Boolean
       REGEX_RELAY_CONNECTION = /Connection$/
       def node_is_relay_connection?(node)
         node.return_type.unwrap.name =~ REGEX_RELAY_CONNECTION
       end
 
       # Predict the association name to include from a field's metadata
+      #
+      # @param node GraphQL::InternalRepresentation::Node
+      # @returns possible_includes Includes
       def node_includes_source_from_metadata(node)
         definition = node.definitions.first
         definition.metadata[:includes] || (definition.property || definition.name).to_sym
@@ -125,6 +173,10 @@ module GraphQLIncludable
 
       # If method_name is delegated from base_model, return an array of
       # associations through which those methods can be delegated
+      #
+      # @param base_model ActiveRecord::Base
+      # @param method_name String | Symbol
+      # @returns chain Array<Symbol>
       def includes_delegated_through(base_model, method_name)
         chain = []
         method = method_name.to_sym
@@ -138,6 +190,9 @@ module GraphQLIncludable
       end
 
       # Right-reduce an array into a nested hash
+      #
+      # @param arr Array<Includes>
+      # @returns nested_hash Includes
       def array_to_nested_hash(arr)
         (arr || []).reject(&:blank?)
                    .reverse

--- a/lib/graphql_includable/resolver.rb
+++ b/lib/graphql_includable/resolver.rb
@@ -141,7 +141,7 @@ module GraphQLIncludable
       def array_to_nested_hash(arr)
         (arr || []).reject(&:blank?)
                    .reverse
-                   .inject { |acc, item| { item => acc } }
+                   .inject { |acc, item| { item => acc } } || {}
       end
     end
   end

--- a/lib/graphql_includable/resolver.rb
+++ b/lib/graphql_includable/resolver.rb
@@ -92,7 +92,7 @@ module GraphQLIncludable
           end
         end
         includes << nested_includes if nested_includes.present?
-        includes.uniq
+        includes.uniq.reject(&:blank?)
       end
 
       # Retrieve the Ruby class for a model by name
@@ -141,7 +141,9 @@ module GraphQLIncludable
 
       # Right-reduce an array into a nested hash
       def array_to_nested_hash(arr)
-        arr.reject(&:blank?).reverse.inject { |acc, item| { item => acc } } || {}
+        (arr || []).reject(&:blank?)
+                   .reverse
+                   .inject { |acc, item| { item => acc } }
       end
     end
   end

--- a/lib/graphql_includable/resolver.rb
+++ b/lib/graphql_includable/resolver.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 module GraphQLIncludable
   class Resolver
     class << self

--- a/spec/graphql_includable_spec.rb
+++ b/spec/graphql_includable_spec.rb
@@ -52,11 +52,4 @@ RSpec.describe GraphQLIncludable, type: :concern do
       expect(includes).to eq([{ apples: [:tree] }])
     end
   end
-
-  context 'when explicitly defining model names' do
-    it 'resolves using the defined model name' do
-      schema.execute('{ prefixedTree { apples { __typename } } }')
-      expect(includes).to eq([:apples])
-    end
-  end
 end

--- a/spec/lib/resolver_spec.rb
+++ b/spec/lib/resolver_spec.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 def get_selection(query)
   GraphQL.parse(query).definitions[0].selections[0]
 end
@@ -100,7 +98,6 @@ describe GraphQLIncludable::Resolver do
     let(:irep_selection) { irep_selection_from_query(schema, 'query { test { with_includes } }') }
 
     it 'uses the :includes definition' do
-      # byebug
       expect(GraphQLIncludable::Resolver.node_includes_source_from_metadata(irep_selection)).to eq(:foo)
     end
     it 'uses the :property definition' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,12 +26,6 @@ shared_examples 'graphql' do
           nil
         end
       end
-      field :prefixedTree, PrefixedTreeType do
-        resolve ->(_obj, _args, ctx) do
-          private_includes = GraphQLIncludable.generate_includes_from_graphql(ctx, 'PrefixedTree')
-          nil
-        end
-      end
       field :orchard, OrchardType do
         resolve ->(_obj, _args, ctx) do
           private_includes = Tree.all.includes_from_graphql(ctx).includes_values


### PR DESCRIPTION
- take 2 at resolving data dependencies through Relay connections and edges
- includes some extra steps to reuse objects with preloaded data in memory instead of additional database round trips to resolve edge records

nb: these changes are *not* yet deployed to rubygems