### PR TITLE
Flexible connection support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,19 +11,28 @@ Style/Lambda:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Metrics/LineLength:
+  Max: 120
+
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/PerceivedComplexity:
+  Max: 10
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 25
 
 Metrics/BlockLength:
   Max: 30
   ExcludedMethods:
     - describe
 
-Metrics/LineLength:
-  Max: 100
+Metrics/ClassLength:
+  Max: 120
 
 Metrics/ModuleLength:
   Max: 150

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+0.4.0
+  - (breaking change) refactored `define_connection_with_fetched_edge` to find edge-to-node properties at the field level rather than type level.
+  - (breaking change) removed `edges_property` and `nodes_property`. Replaced with `includes: {edges: :prop1, nodes: :prop2}`.
+  - added `resolve_edges` and `resolve_nodes` for fetched connections.
+  - added a totalCount field to fetched edge connections.
+  -
 0.3.0
   - improve relay connection support - Deprecated define_includable_connection in favour of define_connection_with_fetched_edge.
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'graphql'
 group :test do
   gem 'rspec'
   gem 'rubocop'
-  gem 'byebug'
 end
 
 group :development do

--- a/graphql_includable.gemspec
+++ b/graphql_includable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'graphql_includable'
-  s.version = '0.4.0.alpha.1'
+  s.version = '0.4.0'
   s.licenses = ['MIT']
   s.summary = 'An ActiveSupport::Concern for GraphQL Ruby to eager-load query data'
   s.authors = ['Dan Rouse', 'Josh Vickery', 'Jordan Hamill']

--- a/graphql_includable.gemspec
+++ b/graphql_includable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'graphql_includable'
-  s.version = '0.3.0'
+  s.version = '0.4.0.alpha.1'
   s.licenses = ['MIT']
   s.summary = 'An ActiveSupport::Concern for GraphQL Ruby to eager-load query data'
   s.authors = ['Dan Rouse', 'Josh Vickery', 'Jordan Hamill']

--- a/lib/graphql_includable.rb
+++ b/lib/graphql_includable.rb
@@ -9,9 +9,11 @@ require 'graphql_includable/relay/instrumentation/connection'
 
 GraphQL::Field.accepts_definitions(
   includes: GraphQL::Define.assign_metadata_key(:includes),
-  edges_property: GraphQL::Define.assign_metadata_key(:edges_property),
-  nodes_property: GraphQL::Define.assign_metadata_key(:nodes_property),
-  edge_to_node_property: GraphQL::Define.assign_metadata_key(:edge_to_node_property)
+  edge_to_node_property: GraphQL::Define.assign_metadata_key(:edge_to_node_property),
+  resolve_edges: GraphQL::Define.assign_metadata_key(:resolve_edges),
+  resolve_nodes: GraphQL::Define.assign_metadata_key(:resolve_nodes),
+  # Internal use
+  _includable_connection_marker: GraphQL::Define.assign_metadata_key(:_includable_connection_marker),
 )
 
 module GraphQL

--- a/lib/graphql_includable.rb
+++ b/lib/graphql_includable.rb
@@ -13,13 +13,13 @@ GraphQL::Field.accepts_definitions(
   resolve_edges: GraphQL::Define.assign_metadata_key(:resolve_edges),
   resolve_nodes: GraphQL::Define.assign_metadata_key(:resolve_nodes),
   # Internal use
-  _includable_connection_marker: GraphQL::Define.assign_metadata_key(:_includable_connection_marker),
+  _includable_connection_marker: GraphQL::Define.assign_metadata_key(:_includable_connection_marker)
 )
 
 module GraphQL
   class BaseType
     def define_includable_connection(**kwargs, &block)
-      warn '[DEPRECATION] `define_includable_connection` is deprecated.  Please use `define_connection_with_fetched_edge` instead.'
+      warn '[DEPRECATION] `define_includable_connection` is deprecated. Use `define_connection_with_fetched_edge`.'
       define_connection(
         edge_class: GraphQLIncludable::Edge,
         **kwargs,

--- a/lib/graphql_includable/concern.rb
+++ b/lib/graphql_includable/concern.rb
@@ -9,7 +9,6 @@ module GraphQLIncludable
         node = Resolver.find_node_by_return_type(ctx.irep_node, name)
         manager = IncludesManager.new(nil)
         Resolver.includes_for_node(node, manager)
-        puts "INCLUDES!!! #{manager.includes}"
         includes(manager.includes)
       rescue => e
         Rails.logger.error(e)

--- a/lib/graphql_includable/concern.rb
+++ b/lib/graphql_includable/concern.rb
@@ -9,6 +9,7 @@ module GraphQLIncludable
         node = Resolver.find_node_by_return_type(ctx.irep_node, name)
         manager = IncludesManager.new(nil)
         Resolver.includes_for_node(node, manager)
+        puts "INCLUDES!!! #{manager.includes}"
         includes(manager.includes)
       rescue => e
         Rails.logger.error(e)

--- a/lib/graphql_includable/edge.rb
+++ b/lib/graphql_includable/edge.rb
@@ -1,3 +1,6 @@
+# rubocop:disable Style/ConditionalAssignment
+# rubocop:disable Lint/HandleExceptions
+# rubocop:disable Metrics/AbcSize
 module GraphQLIncludable
   class Edge < GraphQL::Relay::Edge
     def edge
@@ -9,7 +12,7 @@ module GraphQLIncludable
       root_association_key = class_to_str(parent.class)
       unless edge_class.reflections.keys.include?(root_association_key)
         is_polymorphic = true
-        root_association_key = edge_class.reflections.select { |k, r| r.polymorphic? }.keys.first
+        root_association_key = edge_class.reflections.select { |_k, r| r.polymorphic? }.keys.first
       end
 
       if parent.class.delegate_cache&.key?(edge_class_name)
@@ -39,7 +42,7 @@ module GraphQLIncludable
       end
     end
 
-    def respond_to_missing(method_name, include_private = false)
+    def respond_to_missing?(method_name, include_private = false)
       edge.respond_to?(method_name) || super
     end
 

--- a/lib/graphql_includable/relay/edge_with_node.rb
+++ b/lib/graphql_includable/relay/edge_with_node.rb
@@ -3,8 +3,7 @@ module GraphQLIncludable
     class EdgeWithNode < GraphQL::Relay::Edge
       def initialize(node, connection)
         @edge = node
-        edge_to_node_property = connection.field.type.fields['edges'].metadata[:edge_to_node_property]
-        node = @edge.public_send(edge_to_node_property)
+        node = connection.edge_to_node(@edge)  # TODO: Make lazy
         super(node, connection)
       end
 

--- a/lib/graphql_includable/relay/edge_with_node.rb
+++ b/lib/graphql_includable/relay/edge_with_node.rb
@@ -3,7 +3,7 @@ module GraphQLIncludable
     class EdgeWithNode < GraphQL::Relay::Edge
       def initialize(node, connection)
         @edge = node
-        node = connection.edge_to_node(@edge)  # TODO: Make lazy
+        node = connection.edge_to_node(@edge) # TODO: Make lazy
         super(node, connection)
       end
 
@@ -15,7 +15,7 @@ module GraphQLIncludable
         end
       end
 
-      def respond_to_missing(method_name, include_private = false)
+      def respond_to_missing?(method_name, include_private = false)
         @edge.respond_to?(method_name) || super
       end
     end

--- a/lib/graphql_includable/relay/edge_with_node_connection.rb
+++ b/lib/graphql_includable/relay/edge_with_node_connection.rb
@@ -50,6 +50,11 @@ module GraphQLIncludable
         edge.public_send(@connection_edges_and_nodes.edge_to_node_property)
       end
 
+      def total_count
+        @nodes = determin_page_info_nodes
+        @nodes.size
+      end
+
       private
 
       def args

--- a/lib/graphql_includable/relay/edge_with_node_connection.rb
+++ b/lib/graphql_includable/relay/edge_with_node_connection.rb
@@ -1,9 +1,13 @@
 module GraphQLIncludable
   module Relay
     class ConnectionEdgesAndNodes
-      attr_reader :parent, :args, :ctx, :edges_property, :nodes_property, :edge_to_node_property, :edges_resolver, :nodes_resolver
+      attr_reader :parent, :args, :ctx, :edges_property, :nodes_property, :edge_to_node_property
+      attr_reader :edges_resolver, :nodes_resolver
 
-      def initialize(parent, args, ctx, edges_property, nodes_property, edge_to_node_property, edges_resolver, nodes_resolver)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(parent, args, ctx,
+                     edges_property, nodes_property, edge_to_node_property,
+                     edges_resolver, nodes_resolver)
         @parent = parent
         @args = args
         @ctx = ctx
@@ -13,11 +17,12 @@ module GraphQLIncludable
         @edges_resolver = edges_resolver
         @nodes_resolver = nodes_resolver
       end
+      # rubocop:enable Metrics/ParameterLists
     end
 
     class EdgeWithNodeConnection < GraphQL::Relay::RelationConnection
       def initialize(nodes, *args, &block)
-        @connection_edges_and_nodes = nodes
+        @edges_and_nodes = nodes
         @loaded_nodes = nil
         @loaded_edges = nil
         super(nil, *args, &block)
@@ -28,14 +33,14 @@ module GraphQLIncludable
       end
 
       def fetch_edges
-        @loaded_edges ||= @connection_edges_and_nodes.edges_resolver.call(@connection_edges_and_nodes.parent, args, ctx)
+        @loaded_edges ||= @edges_and_nodes.edges_resolver.call(@edges_and_nodes.parent, args, ctx)
         # Set nodes to make underlying BaseConnection work
         @nodes = @loaded_edges
         @loaded_edges
       end
 
       def fetch_nodes
-        @loaded_nodes ||= @connection_edges_and_nodes.nodes_resolver.call(@connection_edges_and_nodes.parent, args, ctx)
+        @loaded_nodes ||= @edges_and_nodes.nodes_resolver.call(@edges_and_nodes.parent, args, ctx)
         # Set nodes to make underlying BaseConnection work
         @nodes = @loaded_nodes
         @loaded_nodes
@@ -47,7 +52,7 @@ module GraphQLIncludable
       end
 
       def edge_to_node(edge)
-        edge.public_send(@connection_edges_and_nodes.edge_to_node_property)
+        edge.public_send(@edges_and_nodes.edge_to_node_property)
       end
 
       def total_count
@@ -58,23 +63,23 @@ module GraphQLIncludable
       private
 
       def args
-        @connection_edges_and_nodes.args
+        @edges_and_nodes.args
       end
 
       def ctx
-        @connection_edges_and_nodes.ctx
+        @edges_and_nodes.ctx
       end
 
       def determin_page_info_nodes
-        # If the query asks for `pageInfo` before `edges` or `nodes`, we dont directly know which to use most efficently.
-        # We can have a guess by checking if either of the associations are preloaded
+        # If the query asks for `pageInfo` before `edges` or `nodes`, we dont directly know which to use most
+        # efficently. We can have a guess by checking if either of the associations are preloaded
         return @loaded_nodes if @loaded_nodes.present?
         return @loaded_edges if @loaded_edges.present?
 
-        nodes_preloaded = @connection_edges_and_nodes.parent.association(@connection_edges_and_nodes.nodes_property).loaded?
+        nodes_preloaded = @edges_and_nodes.parent.association(@edges_and_nodes.nodes_property).loaded?
         return fetch_nodes if nodes_preloaded
 
-        edges_preloaded = @connection_edges_and_nodes.parent.association(@connection_edges_and_nodes.edges_property).loaded?
+        edges_preloaded = @edges_and_nodes.parent.association(@edges_and_nodes.edges_property).loaded?
         return fetch_edges if edges_preloaded
 
         fetch_nodes

--- a/lib/graphql_includable/relay/edge_with_node_connection_type.rb
+++ b/lib/graphql_includable/relay/edge_with_node_connection_type.rb
@@ -11,6 +11,8 @@ module GraphQLIncludable
           name("#{wrapped_type.name}Connection")
           description("The connection type for #{wrapped_type.name}.")
 
+          field :totalCount, types.Int, "Total count.", property: :total_count
+
           field :edges, types[edge_type], "A list of edges.", edge_class: custom_edge_class, property: :fetch_edges, _includable_connection_marker: true
 
           if nodes_field

--- a/lib/graphql_includable/relay/edge_with_node_connection_type.rb
+++ b/lib/graphql_includable/relay/edge_with_node_connection_type.rb
@@ -2,7 +2,7 @@ module GraphQLIncludable
   module Relay
     class EdgeWithNodeConnectionType
       def self.create_type(
-        wrapped_type, edge_to_node_property:,
+        wrapped_type,
         edge_type: wrapped_type.edge_type, edge_class: EdgeWithNode, nodes_field: GraphQL::Relay::ConnectionType.default_nodes_field, &block
       )
         custom_edge_class = edge_class
@@ -10,7 +10,8 @@ module GraphQLIncludable
         GraphQL::ObjectType.define do
           name("#{wrapped_type.name}Connection")
           description("The connection type for #{wrapped_type.name}.")
-          field :edges, types[edge_type], "A list of edges.", edge_class: custom_edge_class, property: :fetch_edges, edge_to_node_property: edge_to_node_property
+
+          field :edges, types[edge_type], "A list of edges.", edge_class: custom_edge_class, property: :fetch_edges, _includable_connection_marker: true
 
           if nodes_field
             field :nodes, types[wrapped_type],  "A list of nodes.", property: :fetch_nodes

--- a/lib/graphql_includable/relay/edge_with_node_connection_type.rb
+++ b/lib/graphql_includable/relay/edge_with_node_connection_type.rb
@@ -3,7 +3,8 @@ module GraphQLIncludable
     class EdgeWithNodeConnectionType
       def self.create_type(
         wrapped_type,
-        edge_type: wrapped_type.edge_type, edge_class: EdgeWithNode, nodes_field: GraphQL::Relay::ConnectionType.default_nodes_field, &block
+        edge_type: wrapped_type.edge_type, edge_class: EdgeWithNode,
+        nodes_field: GraphQL::Relay::ConnectionType.default_nodes_field, &block
       )
         custom_edge_class = edge_class
 
@@ -11,15 +12,19 @@ module GraphQLIncludable
           name("#{wrapped_type.name}Connection")
           description("The connection type for #{wrapped_type.name}.")
 
-          field :totalCount, types.Int, "Total count.", property: :total_count
+          field :totalCount, types.Int, 'Total count.', property: :total_count
 
-          field :edges, types[edge_type], "A list of edges.", edge_class: custom_edge_class, property: :fetch_edges, _includable_connection_marker: true
-
-          if nodes_field
-            field :nodes, types[wrapped_type],  "A list of nodes.", property: :fetch_nodes
+          field :edges, types[edge_type], 'A list of edges.' do
+            edge_class custom_edge_class
+            property :fetch_edges
+            _includable_connection_marker true
           end
 
-          field :pageInfo, !GraphQL::Relay::PageInfo, "Information to aid in pagination.", property: :page_info
+          if nodes_field
+            field :nodes, types[wrapped_type], 'A list of nodes.', property: :fetch_nodes
+          end
+
+          field :pageInfo, !GraphQL::Relay::PageInfo, 'Information to aid in pagination.', property: :page_info
           block && instance_eval(&block)
         end
       end

--- a/lib/graphql_includable/relay/instrumentation/connection.rb
+++ b/lib/graphql_includable/relay/instrumentation/connection.rb
@@ -2,10 +2,11 @@ module GraphQLIncludable
   module Relay
     module Instrumentation
       class Connection
+        # rubocop:disable Metrics/AbcSize
         def instrument(_type, field)
-          return field unless is_edge_with_node_connection?(field)
+          return field unless edge_with_node_connection?(field)
 
-          raise ArgumentError.new('Connection does not support fetching using :property') if field.property.present?
+          raise ArgumentError, 'Connection does not support fetching using :property' if field.property.present?
 
           validate!(field)
           edge_to_node_property = field.metadata[:edge_to_node_property]
@@ -13,55 +14,70 @@ module GraphQLIncludable
           edges_prop = explicit_includes[:edges]
           nodes_prop = explicit_includes[:nodes]
 
-          if is_proc_based?(field)
+          if proc_based?(field)
             edges_resolver = field.metadata[:resolve_edges]
             nodes_resolver = field.metadata[:resolve_nodes]
           else
             # Use the edges and nodes symbols from the incldues pattern as the propeties to fetch
-            edges_resolver = ->(obj, args, ctx) { obj.public_send(edges_prop) }
-            nodes_resolver = ->(obj, args, ctx) { obj.public_send(nodes_prop) }
+            edges_resolver = ->(obj, _args, _ctx) { obj.public_send(edges_prop) }
+            nodes_resolver = ->(obj, _args, _ctx) { obj.public_send(nodes_prop) }
           end
 
           _original_resolve = field.resolve_proc
           new_resolve_proc = ->(obj, args, ctx) do
-            ConnectionEdgesAndNodes.new(obj, args, ctx, edges_prop, nodes_prop, edge_to_node_property, edges_resolver, nodes_resolver)
+            ConnectionEdgesAndNodes.new(obj, args, ctx,
+                                        edges_prop, nodes_prop, edge_to_node_property,
+                                        edges_resolver, nodes_resolver)
           end
 
           field.redefine { resolve(new_resolve_proc) }
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 
-        def is_edge_with_node_connection?(field)
+        def edge_with_node_connection?(field)
           field.connection? && field.type.fields['edges'].metadata.key?(:_includable_connection_marker)
         end
 
-        def is_proc_based?(field)
+        def proc_based?(field)
           required_metadata = [:resolve_edges, :resolve_nodes]
           has_a_resolver = required_metadata.any? { |key| field.metadata.key?(key) }
 
           return false unless has_a_resolver
-          raise ArgumentError.new("Missing one of #{required_metadata}") unless required_metadata.all? { |key| field.metadata.key?(key) }
+          unless required_metadata.all? { |key| field.metadata.key?(key) }
+            raise ArgumentError, "Missing one of #{required_metadata}"
+          end
 
           true
         end
 
+        # rubocop:disable Metrics/AbcSize
         def validate!(field)
-          raise ArgumentError.new('Missing edge_to_node_property definition for field') unless field.metadata.key?(:edge_to_node_property)
-          raise ArgumentError.new(':edge_to_node_property must be a symbol') unless field.metadata[:edge_to_node_property].is_a?(Symbol)
+          unless field.metadata.key?(:edge_to_node_property)
+            raise ArgumentError, 'Missing edge_to_node_property definition for field'
+          end
+          unless field.metadata[:edge_to_node_property].is_a?(Symbol)
+            raise ArgumentError, ':edge_to_node_property must be a symbol'
+          end
 
-          raise ArgumentError.new('Missing includes definition for field') unless field.metadata.key?(:includes)
+          raise ArgumentError, 'Missing includes definition for field' unless field.metadata.key?(:includes)
           includes = field.metadata[:includes]
-          raise ArgumentError.new('Connection includes must be a hash containing :edges and :nodes keys') unless includes.is_a?(Hash)
-          raise ArgumentError.new('Missing :nodes includes') unless includes.key?(:nodes)
-          raise ArgumentError.new('Missing :edges includes') unless includes.key?(:edges)
-          raise ArgumentError.new(':edges must be a symbol') unless includes[:edges].is_a?(Symbol)
-          raise ArgumentError.new(':nodes must be a symbol') unless includes[:edges].is_a?(Symbol)
+          unless includes.is_a?(Hash)
+            raise ArgumentError, 'Connection includes must be a hash containing :edges and :nodes keys'
+          end
+          raise ArgumentError, 'Missing :nodes includes' unless includes.key?(:nodes)
+          raise ArgumentError, 'Missing :edges includes' unless includes.key?(:edges)
+          raise ArgumentError, ':edges must be a symbol' unless includes[:edges].is_a?(Symbol)
+          raise ArgumentError, ':nodes must be a symbol' unless includes[:edges].is_a?(Symbol)
         end
+        # rubocop:enable Metrics/AbcSize
       end
 
-      GraphQL::Relay::BaseConnection.register_connection_implementation(GraphQLIncludable::Relay::ConnectionEdgesAndNodes, GraphQLIncludable::Relay::EdgeWithNodeConnection)
+      GraphQL::Relay::BaseConnection.register_connection_implementation(
+        GraphQLIncludable::Relay::ConnectionEdgesAndNodes,
+        GraphQLIncludable::Relay::EdgeWithNodeConnection
+      )
     end
-
   end
 end

--- a/lib/graphql_includable/relay/instrumentation/connection.rb
+++ b/lib/graphql_includable/relay/instrumentation/connection.rb
@@ -3,29 +3,65 @@ module GraphQLIncludable
     module Instrumentation
       class Connection
         def instrument(_type, field)
-          return field unless field.connection?
+          return field unless is_edge_with_node_connection?(field)
 
-          required_metadata = [:edges_property, :nodes_property]
-          requires_instrumentation = required_metadata.any? { |key| field.metadata.key?(key) }
+          raise ArgumentError.new('Connection does not support fetching using :property') if field.property.present?
 
-          return field unless requires_instrumentation
-          raise ArgumentError unless required_metadata.all? { |key| field.metadata.key?(key) }
+          validate!(field)
+          edge_to_node_property = field.metadata[:edge_to_node_property]
+          explicit_includes = field.metadata[:includes]
+          edges_prop = explicit_includes[:edges]
+          nodes_prop = explicit_includes[:nodes]
 
-          raise ArgumentError if field.property.present? # TODO: Check for resolve proc too
-
-          edges_prop = field.metadata[:edges_property]
-          nodes_prop = field.metadata[:nodes_property]
+          if is_proc_based?(field)
+            edges_resolver = field.metadata[:resolve_edges]
+            nodes_resolver = field.metadata[:resolve_nodes]
+          else
+            # Use the edges and nodes symbols from the incldues pattern as the propeties to fetch
+            edges_resolver = ->(obj, args, ctx) { obj.public_send(edges_prop) }
+            nodes_resolver = ->(obj, args, ctx) { obj.public_send(nodes_prop) }
+          end
 
           _original_resolve = field.resolve_proc
           new_resolve_proc = ->(obj, args, ctx) do
-            ConnectionEdgesAndNodes.new(obj, edges_prop, nodes_prop)
+            ConnectionEdgesAndNodes.new(obj, args, ctx, edges_prop, nodes_prop, edge_to_node_property, edges_resolver, nodes_resolver)
           end
 
           field.redefine { resolve(new_resolve_proc) }
+        end
+
+        private
+
+        def is_edge_with_node_connection?(field)
+          field.connection? && field.type.fields['edges'].metadata.key?(:_includable_connection_marker)
+        end
+
+        def is_proc_based?(field)
+          required_metadata = [:resolve_edges, :resolve_nodes]
+          has_a_resolver = required_metadata.any? { |key| field.metadata.key?(key) }
+
+          return false unless has_a_resolver
+          raise ArgumentError.new("Missing one of #{required_metadata}") unless required_metadata.all? { |key| field.metadata.key?(key) }
+
+          true
+        end
+
+        def validate!(field)
+          raise ArgumentError.new('Missing edge_to_node_property definition for field') unless field.metadata.key?(:edge_to_node_property)
+          raise ArgumentError.new(':edge_to_node_property must be a symbol') unless field.metadata[:edge_to_node_property].is_a?(Symbol)
+
+          raise ArgumentError.new('Missing includes definition for field') unless field.metadata.key?(:includes)
+          includes = field.metadata[:includes]
+          raise ArgumentError.new('Connection includes must be a hash containing :edges and :nodes keys') unless includes.is_a?(Hash)
+          raise ArgumentError.new('Missing :nodes includes') unless includes.key?(:nodes)
+          raise ArgumentError.new('Missing :edges includes') unless includes.key?(:edges)
+          raise ArgumentError.new(':edges must be a symbol') unless includes[:edges].is_a?(Symbol)
+          raise ArgumentError.new(':nodes must be a symbol') unless includes[:edges].is_a?(Symbol)
         end
       end
 
       GraphQL::Relay::BaseConnection.register_connection_implementation(GraphQLIncludable::Relay::ConnectionEdgesAndNodes, GraphQLIncludable::Relay::EdgeWithNodeConnection)
     end
+
   end
 end

--- a/lib/graphql_includable/resolver.rb
+++ b/lib/graphql_includable/resolver.rb
@@ -88,6 +88,7 @@ module GraphQLIncludable
       connection_children = node.scoped_children[node.return_type.unwrap]
       connection_children.each_value do |connection_node|
         # connection_field {
+        #   totalCount
         #   pageInfo {...}
         #   nodes {
         #     node_model_field ...
@@ -122,6 +123,8 @@ module GraphQLIncludable
           node_children.each_value do |node_child_node|
             includes_for_child(node_child_node, node_model, nodes_includes_manager)
           end
+        elsif connection_node.name == 'totalCount'
+          # Handled using `.size` - if includes() grabbed edges/nodes it will .length else, a COUNT query saving memory.
         end
       end
     end

--- a/lib/graphql_includable/resolver.rb
+++ b/lib/graphql_includable/resolver.rb
@@ -80,7 +80,7 @@ module GraphQLIncludable
       edges_association = associations_from_parent_model[:edges]
       nodes_association = associations_from_parent_model[:nodes]
 
-      edge_node_attribute = node.return_type.fields['edges'].metadata[:edge_to_node_property]
+      edge_node_attribute = node.definition.metadata[:edge_to_node_property]
       edge_model = edges_association.klass
       edge_to_node_association = edge_model.reflect_on_association(edge_node_attribute)
       node_model = edge_to_node_association.klass
@@ -167,15 +167,16 @@ module GraphQLIncludable
 
     def self.node_possible_association_names(node)
       definition = node.definitions.first
+      user_includes = definition.metadata[:includes]
 
       association_names = {}
       if node_is_relay_connection?(node)
-        association_names[:edges] = definition.metadata[:edges_property] if definition.metadata.key?(:edges_property)
-        association_names[:nodes] = definition.metadata[:nodes_property] if definition.metadata.key?(:nodes_property)
-        return association_names if association_names.present? # This should be an includable connection with no :property or name fallback.
+        association_names[:edges] = user_includes[:edges] if user_includes.key?(:edges)
+        association_names[:nodes] = user_includes[:nodes] if user_includes.key?(:nodes)
+        return association_names if association_names.present? # This will have resolve procs for nodes and edges
       end
 
-      association_names[:default] = definition.metadata[:includes] || (definition.property || definition.name).to_sym
+      association_names[:default] = user_includes || (definition.property || definition.name).to_sym
       association_names
     end
 

--- a/spec/lib/edge_spec.rb
+++ b/spec/lib/edge_spec.rb
@@ -32,7 +32,6 @@ describe GraphQLIncludable::Edge do
   context 'connecting a HasManyThroughAssociation' do
     describe 'a method called by the EdgeType' do
       it 'is resolved through the ActiveRecord join model' do
-
       end
     end
   end

--- a/spec/lib/resolver_spec.rb
+++ b/spec/lib/resolver_spec.rb
@@ -34,7 +34,6 @@ describe GraphQLIncludable::Resolver do
 
   describe 'result formatting' do
     it 'places single terminal node as a symbol' do
-
     end
     it 'places multiple terminal nodes as an array of symbols' do
     end
@@ -125,8 +124,7 @@ describe GraphQLIncludable::Resolver do
       class TestModel < ActiveRecord::Base
         include GraphQLIncludable::Concern
         delegate :delegated_method, to: :other_model
-        def normal_method
-        end
+        def normal_method; end
       end
     end
 
@@ -137,17 +135,9 @@ describe GraphQLIncludable::Resolver do
     end
     context 'when the method is delegated' do
       it 'returns an array of delegated models' do
-        expect(GraphQLIncludable::Resolver.includes_delegated_through(TestModel, :delegated_method)).to eq([:other_model])
+        expected = [:other_model]
+        expect(GraphQLIncludable::Resolver.includes_delegated_through(TestModel, :delegated_method)).to eq(expected)
       end
-    end
-  end
-
-  describe '.array_to_nested_hash' do
-    it 'reduces an array to a hash' do
-      expect(GraphQLIncludable::Resolver.array_to_nested_hash([1,2,3])).to eq({ 1 => { 2 => 3 } })
-    end
-    it 'converts an empty array to an empty hash' do
-      expect(GraphQLIncludable::Resolver.array_to_nested_hash([])).to eq({})
     end
   end
 end


### PR DESCRIPTION
- **Breaking change:** Define how to fetch nodes directly and indirectly through edges 
    - Rather than fetching `edges_property` or `nodes_property`, these will be taken from the  `includes` hash.
    ```rb
    includes(edges: :survey_listings, nodes: :listings)
    edge_to_node_property(:listing)
    ```
- **Breaking change:** Refactored `define_connection_with_fetched_edge` to find edge-to-node properties at the field level rather than type level.
    ```rb
    ListingType.define_connection_with_fetched_edge(edge_type: SurveyListingEdgeType)
    ```    
- Override node/edge resolvers using `resolve_edges` and `resolve_nodes`.
     - Will use the properties defined in `includes(edges:, nodes:)` for preloading.
     - Will call `resolve_edges` if `edges` are queried then use `edge_to_node_property` to get the `node`.
     - WIl call `resolve_nodes` id `nodes` are queried directly.
- Adds a `totalCount` field to connections.